### PR TITLE
Bringing the most recent bug fixes from master into dev (#73)

### DIFF
--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -143,7 +143,13 @@ namespace Intersect.Client.Entities
 
         public override bool Update()
         {
-            HandleInput();
+
+            if (Globals.Me == this)
+            {
+                HandleInput();
+            }
+
+
             if (!IsBusy())
             {
                 if (this == Globals.Me && IsMoving == false)

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Event_GraphicSelector.cs
@@ -41,11 +41,13 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
         )
         {
             InitializeComponent();
+            InitLocalization();
             mEditingGraphic = editingGraphic;
             mEventEditor = eventEditor;
             mLoading = true;
+            cmbGraphicType.SelectedIndex = (int)mEditingGraphic.Type;
             UpdateGraphicList();
-            if (cmbGraphic.Items.IndexOf(mEditingGraphic.Filename) > -1)
+            if (cmbGraphic.Items.Contains(mEditingGraphic.Filename))
             {
                 cmbGraphic.SelectedIndex = cmbGraphic.Items.IndexOf(mEditingGraphic.Filename);
             }
@@ -53,8 +55,6 @@ namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
             mRouteDesigner = moveRouteDesigner;
             mNewRouteAction = newMoveRouteAction;
             mLoading = false;
-            InitLocalization();
-            cmbGraphicType.SelectedIndex = (int) mEditingGraphic.Type;
             mTmpGraphic.CopyFrom(mEditingGraphic);
             UpdatePreview();
         }

--- a/Intersect.Server/Database/PlayerData/Api/RefreshToken.cs
+++ b/Intersect.Server/Database/PlayerData/Api/RefreshToken.cs
@@ -86,16 +86,12 @@ namespace Intersect.Server.Database.PlayerData.Api
             return true;
         }
 
+        [CanBeNull]
         public static RefreshToken Find(Guid id)
         {
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return null;
-                }
-
-                return DbInterface.GetPlayerContext()?.RefreshTokens.Find(id);
+                return DbInterface.GetPlayerContext()?.RefreshTokens?.Find(id);
             }
         }
 
@@ -108,23 +104,16 @@ namespace Intersect.Server.Database.PlayerData.Api
 
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return null;
-                }
-
                 var playerContext = DbInterface.GetPlayerContext();
-                var refreshToken = playerContext?.RefreshTokens?.Where(queryToken => queryToken.TicketId == ticketId)
-                    .FirstOrDefault();
+                var refreshToken =
+                    playerContext?.RefreshTokens.FirstOrDefault(queryToken => queryToken.TicketId == ticketId);
 
                 if (refreshToken == null || DateTime.UtcNow < refreshToken.Expires)
                 {
                     return refreshToken;
                 }
-                else
-                {
-                    Remove(refreshToken, true);
-                }
+
+                Remove(refreshToken, true);
             }
 
             return null;
@@ -139,13 +128,8 @@ namespace Intersect.Server.Database.PlayerData.Api
 
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return null;
-                }
-
                 var tokenQuery = DbInterface.GetPlayerContext()
-                    ?.RefreshTokens?.Where(queryToken => queryToken.ClientId == clientId);
+                    ?.RefreshTokens.Where(queryToken => queryToken.ClientId == clientId);
 
                 return tokenQuery.AsEnumerable()?.ToList();
             }
@@ -160,13 +144,8 @@ namespace Intersect.Server.Database.PlayerData.Api
 
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return null;
-                }
-
                 var tokenQuery = DbInterface.GetPlayerContext()
-                    ?.RefreshTokens?.Where(queryToken => queryToken.UserId == userId);
+                    ?.RefreshTokens.Where(queryToken => queryToken.UserId == userId);
 
                 return tokenQuery.AsEnumerable()?.ToList();
             }
@@ -181,13 +160,8 @@ namespace Intersect.Server.Database.PlayerData.Api
         {
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return null;
-                }
-
                 var token = DbInterface.GetPlayerContext()
-                    ?.RefreshTokens?.First(queryToken => queryToken.UserId == userId);
+                    ?.RefreshTokens.First(queryToken => queryToken.UserId == userId);
 
                 return token;
             }
@@ -202,23 +176,13 @@ namespace Intersect.Server.Database.PlayerData.Api
         {
             var token = Find(id);
 
-            if (token == null)
-            {
-                return false;
-            }
-
-            return Remove(token, commit);
+            return token != null && Remove(token, commit);
         }
 
         public static bool Remove([NotNull] RefreshToken token, bool commit = false)
         {
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return false;
-                }
-
                 DbInterface.GetPlayerContext()?.RefreshTokens.Remove(token);
 
                 return true;
@@ -229,11 +193,6 @@ namespace Intersect.Server.Database.PlayerData.Api
         {
             lock (DbInterface.GetPlayerContextLock())
             {
-                if (DbInterface.GetPlayerContext()?.RefreshTokens == null)
-                {
-                    return false;
-                }
-
                 DbInterface.GetPlayerContext()?.RefreshTokens.RemoveRange(tokens);
 
                 return true;

--- a/Intersect.Server/Database/PlayerData/User.cs
+++ b/Intersect.Server/Database/PlayerData/User.cs
@@ -247,7 +247,7 @@ namespace Intersect.Server.Database.PlayerData
                     var context = DbInterface.GetPlayerContext();
                     try
                     {
-                        return QueryUsers(context, page * count, count) ?? throw new InvalidOperationException();
+                        return QueryUsers(context, page * count, count)?.ToList() ?? throw new InvalidOperationException();
                     }
                     catch (Exception exception)
                     {
@@ -259,7 +259,7 @@ namespace Intersect.Server.Database.PlayerData
             }
             else
             {
-                return QueryUsers(playerContext, page, count) ?? throw new InvalidOperationException();
+                return QueryUsers(playerContext, page, count)?.ToList() ?? throw new InvalidOperationException();
             }
         }
 

--- a/Intersect.Server/Entities/Player.Database.cs
+++ b/Intersect.Server/Entities/Player.Database.cs
@@ -154,7 +154,7 @@ namespace Intersect.Server.Entities
         }
 
         [NotNull]
-        public static IEnumerable<Player> List(int page, int count, [CanBeNull] PlayerContext playerContext = null)
+        public static IList<Player> List(int page, int count, [CanBeNull] PlayerContext playerContext = null)
         {
             if (playerContext == null)
             {
@@ -162,12 +162,12 @@ namespace Intersect.Server.Entities
                 {
                     var context = DbInterface.GetPlayerContext();
 
-                    return QueryPlayers(context, page * count, count) ?? throw new InvalidOperationException();
+                    return QueryPlayers(context, page * count, count)?.ToList() ?? throw new InvalidOperationException();
                 }
             }
             else
             {
-                return QueryPlayers(playerContext, page * count, count) ?? throw new InvalidOperationException();
+                return QueryPlayers(playerContext, page * count, count)?.ToList() ?? throw new InvalidOperationException();
             }
         }
 
@@ -192,7 +192,7 @@ namespace Intersect.Server.Entities
                     ? QueryPlayersWithRankAscending(context, page * count, count)
                     : QueryPlayersWithRank(context, page * count, count);
 
-                return results ?? throw new InvalidOperationException();
+                return results?.ToList() ?? throw new InvalidOperationException();
             }
         }
 


### PR DESCRIPTION
* Fixing bugs (#47)

* Should fix 198, server crash due to projectile trying to hit an event

* Harden accept trade packet to return if counterparty is null.

* Fixing potential NREs

* Fixes another potential NRE and out of bounds error

* Don't want to handle packets for null clients, but also don't want to be throwing exceptions

* Fixes a small error where empty passwords crash the server during migration

* Updated licensing leading up to open source release (#49)

* Create FUNDING.yml (#50)

* Use dynamicsoundeffects for music instead of mediaplayer (#51)

* Fixing bugs (#52)

* Should fix 198, server crash due to projectile trying to hit an event

* Harden accept trade packet to return if counterparty is null.

* Fixing potential NREs

* Fixes another potential NRE and out of bounds error

* Don't want to handle packets for null clients, but also don't want to be throwing exceptions

* Fixes a small error where empty passwords crash the server during migration

* Small edit so that networking doesn't alter ui, only triggers ui to update next draw

* Fixed events jumping all over the place

* Allow checking of evtMap parameter even if no page instance has spawned

* Basic bounds checking on pathfinding to potentially fix Weylon's bug.

* Fix for events being able to step on traps.

* Stop caching of expressions as they are used once

* Fixed select character window not resetting paperdolls properly when cycling through characters

* Fixes empty friends list when opening friends via a hotkey

* Added server loop lock for when updating game objects (less likely to have deadlocks if not processing npcs when updating npcs, for example)

* Fix collection changed bug when maps update while server loop is running

* Fixes weird instance where the server would error while trying to send a map to a client who didn't have an entity set

* Adds SpellCd back into the PlayerContextModelSnapshot since it was never actually removed from the database. (#56)

* Fixing db context model snapshot formatting (#58)

* Adds SpellCd back into the PlayerContextModelSnapshot since it was never actually removed from the database.

* EF expected formatting fix for game context model snapshot

* We don't need to be handling input for all the players we are updating only our player. (#62)

* Properly load list data within locking region (#70)

* Cleanup code in RefreshToken

* Actually load list data before exiting locking region

* Fix event graphic selector not opening to current graphic (#72)

Co-authored-by: Robert Lodico <lodico.rj@gmail.com>